### PR TITLE
Updated gen.xml to create the gen dir

### DIFF
--- a/languages/shared/gen.xml
+++ b/languages/shared/gen.xml
@@ -9,6 +9,7 @@
 
 	
 	<!-- generates Java files from JastAdd specs -->
+	<mkdir dir="${basedir}/${gen.dir}" />
 	<target name="jastadd" depends="def.jastadd.task">
     <jastadd package="${x10.ast.pkg}" beaver="true" rewrite="regular" outdir="${basedir}/${gen.dir}">
       <fileset dir="${src.dir}/${x10.src.dir}">


### PR DESCRIPTION
added a mkdir task to create the gen directory if it does not exist. Nothing extra will be done if it already exists. 
Not having a gen dir caused the build to fail.