### PR TITLE
Removed redundant check for absence of --help

### DIFF
--- a/languages/Natlab/src/natlab/MiX10Main.java
+++ b/languages/Natlab/src/natlab/MiX10Main.java
@@ -44,13 +44,13 @@ public class MiX10Main {
 		options = new MiX10Options();
 		options.parse(args);
 
-    if (options.help()) {
-      options.getUsage();
-      return;
-    }
+    		if (options.help()) {
+      			options.getUsage();
+      			return;
+    		}
 
 		if (options.mix10c()) {
-			if (options.files().isEmpty() && !options.help()) {
+			if (options.files().isEmpty()) {
 				if (!options.main().isEmpty()) {
 					/*
 					 * If the user provided an entry point function and did not


### PR DESCRIPTION
Now that --help is being handled separately and the program returns after printing help if --help switch is on, there is no need to explicitly check for its absence while processing --main and --files switches.